### PR TITLE
Korjaa linkin nimi ja päivitä herokun viasta

### DIFF
--- a/laskarit/1.md
+++ b/laskarit/1.md
@@ -521,6 +521,9 @@ Pushaa koodi Githubiin ja varmista, että Codecov generoi raportin siten, että 
 
 **HUOM:** Heroku-palvelussa olevan [vian](https://status.heroku.com/incidents/1334) takia tehtävän ohjelma ei tällä hetkellä (ti klo 15.25) toimi. Toivotaan että vika korjautuu pian.
 
+**PÄIVITYS:** Tehtävän pitäisi nyt toimia (ti klo 20.50).
+
+
 *  kurssirepositorion hakemistossa [koodi/viikko2/NHLStatistics1](https://github.com/mluukkai/ohjelmistotuotanto2017/tree/master/koodi/viikko1/NhlStatistics1) on ohjelma, jonka avulla on mahdollista tutkia [http://nhl.com](http://nhl.com)-sivulla olevia, vuoden 2013-14 tilastotietoja
 
 * Ohjelma koostuu kolmesta luokasta.
@@ -545,7 +548,7 @@ Statistics stats = new Statistics( new PlayerReader("http://nhlstats-2013-14.her
 ## 16.  NHLStatistics-ohjelman yksikkötestaus
 
 * tee yksikkötestit luokalle Statistics
-  * testien kattavuuden (sekä instructions että branches) tulee (Statistics-luokan osalta) olla 100% (mitataan JaCoCo:lla, ks. [tehtävä 7](https://github.com/mluukkai/ohjelmistotuotanto2017/blob/master/laskarit/1.md#8-junit)
+  * testien kattavuuden (sekä instructions että branches) tulee (Statistics-luokan osalta) olla 100% (mitataan JaCoCo:lla, ks. [tehtävä 8](https://github.com/mluukkai/ohjelmistotuotanto2017/blob/master/laskarit/1.md#8-junit)
   * testit eivät saa käyttää verkkoyhteyttä
   * verkkoyhteyden tarpeen saat eliminoitua luomalla testiä varten rajapinnan Reader-toteuttavan "stubin", jonka sisälle kovakoodaat palautettavan pelaajalistan
   * voit luoda stubin testin sisälle anonyyminä sisäluokkana seuraavasti:


### PR DESCRIPTION
Linkki vei tehtävään 8 vaikka siinä luki tehtävä 7, ja Heroku on korjannut tehtävään 15 vaikuttaneen vian.

Tehtävät olivat mielestäni aiheeltaan hyödyllisiä. Gitistä olisi voinut käsitellä workflowta syvällisemmin, esimerkiksi branchejä ja niiden merkitystä ryhmätyössä. Gittiä tosin varmasti käsitellään vielä myöhemmin kurssilla, eli ehkä sitä ei ole tarkoituksenmukaista käsitellä nyt. Muuten tehtävät olivat sopivia ja erityisesti injektointi oli mielenkiintoista.