### PR TITLE
Täginumeroinnin päivitys

### DIFF
--- a/laskarit/4.md
+++ b/laskarit/4.md
@@ -289,7 +289,7 @@ Tarkasta viikoilla 1 ja 2 käytetyn [JaCoCon](https://github.com/mluukkai/ohjelm
 
 Jotain taitaa puuttua. Lisää testi, joka nostaa kattavuuden noin sataan prosenttiin!
 
-Commitoi tehtävän koodi ja lisää commitille tagi lh4_4. Pushaa koodi ja tagi githubin.
+Commitoi tehtävän koodi ja lisää commitille tagi lh4_5. Pushaa koodi ja tagi githubin.
 
 ## Mock-olioiden käytöstä
 


### PR DESCRIPTION
Täginumerot menevät viikon 4 tehtävissä hieman epäloogisesti. Näin voisi päivittää numerointia - tällöin lopussa olevan numero täsmäisi nykyiseen tehtävän numeroon. Numerointi varmaan sekoittunut kurssin evoluution myötä.